### PR TITLE
Fix: rsa key generation

### DIFF
--- a/src/rsa.py
+++ b/src/rsa.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 from src.utils import *
-from random import randint
 from math import gcd
 
 def isPrime(n: int) -> bool:
@@ -9,7 +8,6 @@ def isPrime(n: int) -> bool:
         if n % i == 0:
             return False
     return True
-
 
 def encrypt_rsa(message: str, key: str, left, right) -> str:
     message_bytes = little_endian(hex_to_bytes(string_to_hex(message)))
@@ -42,12 +40,12 @@ def getModInverse(e: int, phi: int) -> int:
     y1 = 1
     temp_phi = phi
 
-    while e > 0:
-        temp1 = temp_phi // e
-        temp2 = temp_phi - temp1 * e
-        temp_phi = e
-        e = temp2
-
+def getMaxFermatPrimeNumber(phi: int) -> int:
+    fermat_primes = [3, 5, 17, 257, 65537]
+    for prime in fermat_primes[::-1]:
+        if phi > prime > 1 == gcd(prime, phi):
+            return prime
+    return 0
         x = x2 - temp1 * x1
         y = d - temp1 * y1
 
@@ -65,11 +63,11 @@ def generateKeys(p: str, q:str):
     p = hex_to_int(p)
     q = hex_to_int(q)
 
-    n = p * q
-    phi = (p - 1) * (q - 1)
-    e = 65737
-    while gcd(e, phi) != 1:
-        e = randint(2, phi - 1)
+    n = new_p * new_q
+    phi = (new_p - 1) * (new_q - 1)
+    e = getMaxFermatPrimeNumber(phi)
+    if gcd(e, phi) != 1 or e == 0:
+        return "Error: e and phi aren't coprime, choose different p and q."
 
     d = getModInverse(e, phi)
     n_little_endian = little_endian(int_to_bytes(n))

--- a/src/rsa.py
+++ b/src/rsa.py
@@ -60,8 +60,8 @@ def getMaxFermatPrimeNumber(phi: int) -> int:
 def generateKeys(p: str, q:str):
     if not p or not q:
         return "p and q must be provided."
-    p = hex_to_int(p)
-    q = hex_to_int(q)
+    new_p = bytes_to_int(little_endian(hex_to_bytes(p)))
+    new_q = bytes_to_int(little_endian(hex_to_bytes(q)))
 
     n = new_p * new_q
     phi = (new_p - 1) * (new_q - 1)

--- a/src/rsa.py
+++ b/src/rsa.py
@@ -33,12 +33,18 @@ def rsa(message: str, key: str, encrypt: bool, block_mode: bool, left, right) ->
         return encrypt_rsa(message, key, left, right)
     return decrypt_rsa(message, key, left, right)
 
+def ext_gdc(a: int, b: int):
+    if a == 0:
+        return b, 0, 1
+    gdc, x, y = ext_gdc(b % a, a)
+    return gdc, y - (b // a) * x, x
+
 def getModInverse(e: int, phi: int) -> int:
-    d = 0
-    x1 = 0
-    x2 = 1
-    y1 = 1
-    temp_phi = phi
+    gdc, x, y = ext_gdc(e, phi)
+    if gdc != 1:
+        print("Error: e and phi aren't coprime, choose different p and q.")
+        exit(84)
+    return x % phi
 
 def getMaxFermatPrimeNumber(phi: int) -> int:
     fermat_primes = [3, 5, 17, 257, 65537]
@@ -46,16 +52,6 @@ def getMaxFermatPrimeNumber(phi: int) -> int:
         if phi > prime > 1 == gcd(prime, phi):
             return prime
     return 0
-        x = x2 - temp1 * x1
-        y = d - temp1 * y1
-
-        x2 = x1
-        x1 = x
-        d = y1
-        y1 = y
-
-    if temp_phi == 1:
-        return d + phi
 
 def generateKeys(p: str, q:str):
     if not p or not q:


### PR DESCRIPTION
I fixed all the rsa key generation computes.

Starting with the n:
- `p` was not in little endian
- `q` was not in little endian

Then e:
- I didn't get the subject update that says that e was to be the highest fermat prime number that confirms phi > e > 1

Finally:
- The `d` computation thanks to the modular multiplicative inverse was wrong