### PR TITLE
fix: check 128 bits key for AES

### DIFF
--- a/src/parse.py
+++ b/src/parse.py
@@ -88,6 +88,9 @@ class pgpArgs():
             except:
                 print("Invalid key format.", file=sys.stderr)
                 return False
+        if (self.crypto_system == "aes" and len(self.KEY) != 32):
+            print("Invalid key length.", file=sys.stderr)
+            return False
         return True
 
     def displayArgs(self):


### PR DESCRIPTION
Check the key length before executing aes crypt/decrypt.